### PR TITLE
Support headers injection/extraction as Map[String, String]

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ sbt run exampleOpenTracing/run
 once the program finished, navigate to [localhost:16686](localhost:16686/), then from the first drop down menu select "pure-application", then click find traces.
  
 ## Todo
-- [ ] Add `inject` & `extract` methods to Tracer
+- [x] Add `inject` & `extract` methods to Tracer
 - [ ] Integrate with http-client library to propagation outgoing http calls
 - [ ] Integrate with http4s to propagate from incoming http calls
 - [ ] AWS XRay implementation

--- a/api/src/main/scala/puretracing/api/Propagation.scala
+++ b/api/src/main/scala/puretracing/api/Propagation.scala
@@ -6,8 +6,10 @@ package puretracing.api
   */
 trait Tracer[F[_]] {
   type Span
+  type Headers = Map[String, String] // TODO: Make this param, perefebly on the methods not the whole trait
 
-  def startRootSpan(operationName: String): F[Span]
+  def startRootSpan(operationName: String, upstreamSpan: Headers): F[Span]
+  def export(span: Span): F[Headers]
   def startChild(span: Span, operationName: String): F[Span]
   def finish(span: Span): F[Unit]
   def setTag(span: Span, key: String, value: TracingValue): F[Unit]

--- a/cats-opentracing/src/main/scala/puretracing/cats/opentracing/OpenTracingTracing.scala
+++ b/cats-opentracing/src/main/scala/puretracing/cats/opentracing/OpenTracingTracing.scala
@@ -1,6 +1,12 @@
 package puretracing.cats.opentracing
 
+
+import io.opentracing.propagation.{Format, TextMapExtractAdapter, TextMapInjectAdapter}
+
+import scala.collection.JavaConverters._
+import cats.syntax.all._
 import cats.effect.Sync
+
 import puretracing.api.{Tracer, TracingValue}
 
 /**
@@ -9,8 +15,23 @@ import puretracing.api.{Tracer, TracingValue}
 class OpenTracingTracing[F[_]](tracer: io.opentracing.Tracer)(implicit F: Sync[F]) extends Tracer[F] {
   override type Span = io.opentracing.Span
 
-  override def startRootSpan(operationName: String): F[Span] =
-    F.delay(tracer.buildSpan(operationName).start())
+  override def startRootSpan(operationName: String, upstreamSpan: Headers): F[Span] = { 
+    import io.opentracing.propagation._
+    import scala.collection.JavaConverters._
+    import cats.syntax.all._
+    for {
+      upstream <- F.catchNonFatal(tracer.extract(Format.Builtin.HTTP_HEADERS, new TextMapExtractAdapter(upstreamSpan.asJava)))
+    } yield tracer.buildSpan(operationName).asChildOf(upstream).start()
+  }
+
+  override def export(span: Span): F[Headers] = { 
+    
+    val carrier = new java.util.HashMap[String, String]() // Warning, mutability ahead!
+    
+    for {
+      _ <- F.catchNonFatal(tracer.inject(span.context, Format.Builtin.HTTP_HEADERS, new TextMapInjectAdapter(carrier)))
+    } yield carrier.asScala.toMap // convert back to immutability land
+  }
 
   override def startChild(span: Span, operationName: String): F[Span] =
     F.delay(tracer.buildSpan(operationName).asChildOf(span).start())

--- a/cats/src/main/scala/puretracing/cats/instances/ReaderTPropagation.scala
+++ b/cats/src/main/scala/puretracing/cats/instances/ReaderTPropagation.scala
@@ -17,8 +17,11 @@ class ReaderTPropagation[F[_]: Applicative](val tracer: Tracer[F]) {
       override def useSpanIn[A](span: Span)(fa: Effect[A]): Effect[A] =
         ReaderT.local[F, A, Span](_ => span)(fa)
 
-      override def startRootSpan(operationName: String): Effect[Span] =
-        ReaderT.liftF[F, Span, Span](tracer.startRootSpan(operationName))
+      override def startRootSpan(operationName: String, upstreamSpan: Headers): Effect[Span] = 
+        ReaderT.liftF(tracer.startRootSpan(operationName, upstreamSpan))
+
+      override def export(span: Span): Effect[Headers] = 
+        ReaderT.liftF(tracer.export(span))
 
       override def startChild(span: Span, operationName: String): Effect[Span] =
         ReaderT.liftF(tracer.startChild(span, operationName))

--- a/cats/src/main/scala/puretracing/cats/noTracing.scala
+++ b/cats/src/main/scala/puretracing/cats/noTracing.scala
@@ -16,10 +16,12 @@ object noTracing {
 class NoopPropagation[F[_]](implicit F: Applicative[F]) extends Propagation[F] {
   override type Span = Unit
   private val dummy = F.pure(())
+  private val dummyHeaders = F.pure(Map.empty[String, String])
 
   override def currentSpan(): F[Unit] = dummy
   override def useSpanIn[A](span: Unit)(fa: F[A]): F[A] = fa
-  override def startRootSpan(operationName: String): F[Unit] = dummy
+  override def startRootSpan(operationName: String, upstreamSpan: Headers): F[Unit] = dummy
+  override def export(span: Unit): F[Headers] = dummyHeaders
   override def startChild(span: Unit, operationName: String): F[Unit] = dummy
   override def finish(span: Unit): F[Unit] = dummy
   override def setTag(span: Unit, key: String, v: TracingValue): F[Unit] = dummy

--- a/examples/lib/src/main/scala/Services.scala
+++ b/examples/lib/src/main/scala/Services.scala
@@ -1,5 +1,5 @@
 import cats.data.ReaderT
-import cats.{Applicative, Functor, ~>}
+import cats.{Applicative, Functor, ~>, FlatMap}
 import cats.effect.{Bracket, IO}
 import cats.syntax.all._
 import cats.instances.list._
@@ -9,11 +9,14 @@ import puretracing.cats.dsl._
 /**
   * Tracing Aware Algebra
   */
-class FooAlgebra[F[_]: Propagation](algebra: BarAlgebra[F]) {
+class FooAlgebra[F[_]: Propagation](algebra: BarAlgebra[F], http: InstrumentedHttpClient[F]) {
 
   def foo()(implicit F: Bracket[F, Throwable]): F[Int] =
     inChildSpan[F]("foo", "user_id" -> 3) { span =>
       span.log("event" -> "foo happened") *>
+        http.request("GET", "127.0.0.1") *>
+        http.request("GET", "127.0.0.2") *>
+        inChildSpan[F]("inner") { _ => http.request("POST", "127.0.0.3/lol") } *>
         (1 to 21).toList.traverse(_ => algebra.bar()).map(_.sum)
     }
 }
@@ -54,4 +57,20 @@ object Console {
   implicit val ioConsoleImpl: Console[IO] = (a: Any) => IO(println(a))
   implicit def readerTImpl[F[_], A](implicit console: Console[F]): Console[ReaderT[F, A, ?]] =
     a => ReaderT.liftF(console.println(a))
+}
+
+// Example how to instrument an http client to propagate headers
+class InstrumentedHttpClient[F[_]: FlatMap](implicit console: Console[F], tracer: Propagation[F]) {
+  import cats.syntax.all._
+
+  def request(method: String, url: String): F[Unit] = 
+    for { 
+      span <- tracer.currentSpan
+      headers <- tracer.export(span)
+      // Simulate http request
+      _ <- Console[F].println(s"┌$method $url HTTP/1.1")
+      _ <- Console[F].println(headers.map { case (k,v) => s"$k: $v" }.mkString("│", " \n", ""))
+      _ <- Console[F].println(s"│Keep-Alive: 300")
+      _ <- Console[F].println(s"└Connection: keep-alive")
+    } yield ()
 }


### PR DESCRIPTION
First stab at supporting span propagation across boundaries. This commit provides the necessary functionality in order to instrument http servers and/or clients.

Under examples there is a dummy http client implementation that just logs to console.
![screenshot 2018-12-24 at 21 57 28](https://user-images.githubusercontent.com/725206/50407014-fb25fa80-07c6-11e9-9229-af55b73a2d3b.png)
The image above shows 3 http requests, first 2 are sent from the same span, so they have identical headers. But the third is sent from a child span, so it has a slightly different headers, but still sharing the same trace id (the first segment of the `uber-trace-id`).

Note the key `uber-trace-id` is just the default value provided by `JaegerTracer`, which is configurable of course, and also depends on which `io.opentracing.Tracer` implementation the user choose to provide.
