### PR TITLE
Sttp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ once the program finished, navigate to [localhost:16686](localhost:16686/), then
  
 ## Todo
 - [x] Add `inject` & `extract` methods to Tracer
-- [ ] Integrate with http-client library to propagation outgoing http calls
+- [x] Integrate with http-client library to propagation outgoing http calls
 - [ ] Integrate with http4s to propagate from incoming http calls
 - [ ] AWS XRay implementation
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ lazy val cats = project.dependsOn(api).settings(libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-effect" % "1.0.0"
 ))
 lazy val `cats-opentracing` = project.dependsOn(cats).settings(libraryDependencies += "io.opentracing" % "opentracing-api" % "0.31.0")
+lazy val sttp = project.dependsOn(api).settings(libraryDependencies += "com.softwaremill.sttp" %% "core" % "1.5.2")
 
 // TODO: Example that sends HTTP requests
 lazy val exampleLib = project.in(file("examples/lib")).dependsOn(cats).settings(libraryDependencies += "org.typelevel" %% "cats-effect" % "1.0.0")

--- a/cats/src/main/scala/puretracing/cats/instances/ReaderTPropagation.scala
+++ b/cats/src/main/scala/puretracing/cats/instances/ReaderTPropagation.scala
@@ -2,7 +2,7 @@ package puretracing.cats.instances
 
 import cats.Applicative
 import cats.data.ReaderT
-import cats.effect.{Bracket, Sync}
+import cats.effect.Sync
 import cats.effect.syntax.bracket._
 import cats.syntax.flatMap._
 import cats.syntax.functor._

--- a/sttp/src/main/scala/puretracing/sttp/HeaderPropagationBackend.scala
+++ b/sttp/src/main/scala/puretracing/sttp/HeaderPropagationBackend.scala
@@ -1,0 +1,17 @@
+package puretracing.sttp
+
+import com.softwaremill.sttp.{MonadError, Request, Response, SttpBackend}
+import puretracing.api.Propagation
+
+class HeaderPropagationBackend[R[_], S](delegate: SttpBackend[R, S])(implicit propagation: Propagation[R]) extends SttpBackend[R, S] {
+
+  override def send[T](request: Request[T, S]): R[Response[T]] =
+    responseMonad.flatMap(propagation.currentSpan){ span =>
+      responseMonad.flatMap(propagation.export(span)){ tracingHeaders =>
+        delegate.send(request.copy(headers = request.headers ++ tracingHeaders))
+      }
+    }
+
+  override def close(): Unit = delegate.close()
+  override def responseMonad: MonadError[R] = delegate.responseMonad
+}

--- a/sttp/src/main/scala/puretracing/sttp/InstrumentedBackend.scala
+++ b/sttp/src/main/scala/puretracing/sttp/InstrumentedBackend.scala
@@ -1,0 +1,49 @@
+package puretracing.sttp
+
+import com.softwaremill.sttp.{MonadError, Request, Response, SttpBackend, monadSyntax}
+import monadSyntax._
+import puretracing.api.Propagation
+
+object InstrumentedBackend {
+  def apply[R[_], S](inner: SttpBackend[R, S])(implicit tracing: Propagation[R]): SttpBackend[R, S] =
+    instance(inner, tracing)(
+      req => s"${req.method.m}-${req.uri.host}${req.uri.port.map(p => s":$p").getOrElse("")}",
+      (_, _) => inner.responseMonad.unit(()),
+      (_, _, _) => inner.responseMonad.unit(()),
+    )
+
+  def instance[R[_], S](inner: SttpBackend[R, S], tracing: Propagation[R])(
+    operationName: Request[_, S] => String,
+    instrumentation: (Request[_, S], tracing.Span) => R[Unit],
+    logError: (Throwable, Request[_, S], tracing.Span) => R[Unit]
+  ): SttpBackend[R, S] =
+    new SttpBackend[R, S] {
+      val delegate: SttpBackend[R, S] = new HeaderPropagationBackend(inner)(tracing)
+      implicit val ME: MonadError[R] = inner.responseMonad
+
+      override def send[T](request: Request[T, S]): R[Response[T]] =
+        for {
+          parent <- tracing.currentSpan()
+          span <- tracing.startChild(parent, operationName(request))
+          _ <- instrumentation(request, span)
+          response <- sendAndCloseSpan(request, span)
+        } yield response
+
+      override def close(): Unit = delegate.close()
+      override def responseMonad: MonadError[R] = delegate.responseMonad
+
+      def sendAndCloseSpan[T](request: Request[T, S], span: tracing.Span): R[Response[T]] = {
+        def finalizer = tracing.finish(span) // def because R might be something eager, like Future
+
+        val right: R[Either[Throwable, Response[T]]] = delegate.send(request).flatMap(a => finalizer.map(_ => Right(a)))
+        val attempt = responseMonad.handleError(right) { case err =>
+          logError(err, request, span).flatMap(_ => finalizer.map(_ => Left(err)))
+        }
+
+        attempt.flatMap(_.fold(
+          e => ME.error(e),
+          res => ME.unit(res)
+        ))
+      }
+    }
+}


### PR DESCRIPTION
HTTP Client (STTP) Support

Implemented as 2 wrappers.
- HeaderPropagationBackend: Adds trace id to the outgoing request headers
- InstrumentedBackend: Like above, but also create a span and logs against it

